### PR TITLE
Fix PrivateRoute logic to correctly restrict access based on authentication

### DIFF
--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,7 +1,14 @@
 import { Navigate } from 'react-router-dom';
+import { getUserData } from '../utils/getUserData';
 
 const PrivateRoute = ({ children }: { children: JSX.Element }) => {
-  const isAuthenticated = !!localStorage.getItem('jwt-response');
+  const user = getUserData();
+
+  const isAuthenticated =
+    user !== null &&
+    typeof user.jwt === "string" &&
+    user.jwt.length > 0 &&
+    user.roles?.includes("ROLE_USER");
 
   return isAuthenticated ? children : <Navigate to="/login" />;
 };

--- a/frontend/src/utils/fetches/auth.ts
+++ b/frontend/src/utils/fetches/auth.ts
@@ -42,7 +42,6 @@ export const registerUser = async (credentials: UserCredentials): Promise<AuthRe
     const data = await response.json();
 
     if (response.ok) {
-        localStorage.setItem('jwt-response', JSON.stringify(data));
         return data;
     } else {
         const errorMessage = data?.message || 'Registration failed';


### PR DESCRIPTION
PrivateRoute.tsx and auth.ts files are corrected, now withour ROLE_USER and jwt token you can not navigate to any page except login and register pages, if you try to navigate you will be directed to the login page immediately